### PR TITLE
deps: add dvc[testing] to requirements

### DIFF
--- a/dvc-{{cookiecutter.plugin_name}}/setup.cfg
+++ b/dvc-{{cookiecutter.plugin_name}}/setup.cfg
@@ -32,7 +32,7 @@ install_requires =
 [options.extras_require]
 tests =
     wheel==0.37.0
-    dvc
+    dvc[testing]
     # Test requirements
     pytest==6.2.5
     pytest-cov==3.0.0


### PR DESCRIPTION
This fixes CI failures for plugins:
For context:

- https://github.com/iterative/dvc/pull/8296 introduced [`pytest-test-utils`](https://github.com/iterative/pytest-test-utils) dependency because of `test_filesystem` using the `M` fixture.  
- https://github.com/iterative/dvc/pull/8314 introduces a `testing` extra to include all required dependencies for `dvc.testing`

