### PR TITLE
refactor gha workflow

### DIFF
--- a/dvc-{{cookiecutter.plugin_name}}/.github/workflows/release.yaml
+++ b/dvc-{{cookiecutter.plugin_name}}/.github/workflows/release.yaml
@@ -1,23 +1,30 @@
 name: Release
+
 on:
   release:
     types: [published]
+
+permissions:
+  contents: read
+
 jobs:
   pip:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v3
+    - uses: actions/setup-python@v3
       with:
         python-version: 3.8
-    - name: Build packages
+    - name: Install
       run: |
-        pip install -U pip
-        pip install -U build setuptools>=58.2
-        python -m build --sdist --wheel --outdir dist/
+        pip install -U-upgrade pip wheel
+        pip install build twine
+    - name: Build
+      run: |
+        python -m build
+        twine check dist/*
     - name: Publish packages to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:

--- a/dvc-{{cookiecutter.plugin_name}}/.github/workflows/tests.yaml
+++ b/dvc-{{cookiecutter.plugin_name}}/.github/workflows/tests.yaml
@@ -1,42 +1,21 @@
 name: Tests
 
 on:
-  pull_request: {}
-  push: {}
+  push:
+    branches: [main]
+  pull_request:
   schedule:
     - cron: '5 1 * * *'  # every day at 01:05
-
   workflow_dispatch:
 
-env:
-  DVC_TEST: "true"
-  HOMEBREW_NO_AUTO_UPDATE: 1
-  SHELL: /bin/bash
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
 
 jobs:
-  lint:
-    timeout-minutes: 10
-    runs-on: ubuntu-latest
-    steps:
-    - name: Cancel Previous Runs
-      uses: styfle/cancel-workflow-action@0.9.1
-      with:
-        access_token: {% raw %}${{ github.token }}{% endraw %}
-    - uses: actions/checkout@v2.4.0
-      with:
-        fetch-depth: 0
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v2.2.2
-      with:
-        python-version: 3.8
-    - name: Install requirements
-      run: |
-        pip install wheel
-        pip install -e '.[tests]'
-        pip install git+https://github.com/iterative/dvc pre-commit
-    - name: Check README
-      run: python setup.py checkdocs
-    - uses: pre-commit/action@v2.0.3
   tests:
     timeout-minutes: 45
     runs-on: {% raw %}${{ matrix.os }}{% endraw %}
@@ -45,28 +24,33 @@ jobs:
       matrix:
         os: [ubuntu-20.04, windows-latest, macos-latest]
         pyv: ["3.8", "3.9", "3.10", "3.11"]
+
     steps:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
+  
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
         python-version: {% raw %}${{ matrix.pyv }}{% endraw %}
         cache: 'pip'
         cache-dependency-path: setup.cfg
+
     - name: install
       run: |
-        pip install --upgrade pip setuptools wheel
+        pip install --upgrade pip wheel
         pip install -e ".[tests]"
-        pip install "dvc[testing]@git+https://github.com/iterative/dvc"
-    - name: setup git
-      run: |
-        git config --global user.email "dvctester@example.com"
-        git config --global user.name "DVC Tester"
+        pip install "dvc[testing] @ git+https://github.com/iterative/dvc"
+
+    - name: lint
+      timeout-minutes: 10
+      uses: pre-commit/action@v3.0.0
+
     - name: run tests
-      timeout-minutes: 40
+      timeout-minutes: 15
       run: pytest -v -n=auto --cov-report=xml --cov-report=term
+
     - name: upload coverage report
       uses: codecov/codecov-action@v2.1.0
       with:

--- a/dvc-{{cookiecutter.plugin_name}}/.github/workflows/update-template.yaml
+++ b/dvc-{{cookiecutter.plugin_name}}/.github/workflows/update-template.yaml
@@ -3,14 +3,13 @@ name: Update template
 on:
   schedule:
     - cron: '5 1 * * *'  # every day at 01:05
-
   workflow_dispatch:
 
 jobs:
   update:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Install deps
       run: pip install cruft
     - name: Update template
@@ -25,4 +24,3 @@ jobs:
         commit-message: update template
         title: update template
         token: {% raw %}${{ secrets.WORKFLOW_TOKEN }}{% endraw %}
-


### PR DESCRIPTION
- Simplify
- Add concurrency and permissions.
- Update github actions
- Merge lint and tests into one job, so that linters are run in multiple python versions and environments.