### PR TITLE
fix flake8 config

### DIFF
--- a/dvc-{{cookiecutter.plugin_name}}/setup.cfg
+++ b/dvc-{{cookiecutter.plugin_name}}/setup.cfg
@@ -67,11 +67,15 @@ tests =
 
 [flake8]
 ignore=
-    E203, # Whitespace before ':'
-    E266, # Too many leading '#' for block comment
-    W503, # Line break occurred before a binary operator
-    P1,  # unindexed parameters in the str.format, see:
+    # Whitespace before ':'
+    E203,
+    # Too many leading '#' for block comment
+    E266,
+    # Line break occurred before a binary operator
+    W503,
+    # unindexed parameters in the str.format, see:
     # https://pypi.org/project/flake8-string-format/
+    P1,
 max_line_length = 79
 max-complexity = 15
 select = B,C,E,F,W,T4,B902,T,P


### PR DESCRIPTION
See https://flake8.pycqa.org/en/latest/user/configuration.html, especially the line related to inline comments.

Note that with the current (inline) syntax, flake8>6 will break