### PR TITLE
add pre-commit hook to stop .rej files

### DIFF
--- a/dvc-{{cookiecutter.plugin_name}}/.pre-commit-config.yaml
+++ b/dvc-{{cookiecutter.plugin_name}}/.pre-commit-config.yaml
@@ -3,6 +3,12 @@ ci:
 
 repos:
   - hooks:
+      - id: no rej
+        name: Check for .rej files
+        entry: .rej files found, fix conflicts from these rejected files.
+        language: fail
+        files: \.rej$
+  - hooks:
       - id: black
         language_version: python3
     repo: https://github.com/ambv/black


### PR DESCRIPTION
The only problem is that all the plugins needs to be updated for this to really work. 

#### Example Output

```console
Check for .rej files.....................................................Failed
- hook id: no rej
- exit code: 1

.rej files found, fix conflicts from these rejected files.

dvc_oss/tests/cloud.py.rej
dvc_oss/tests/conftest.py.rej
dvc_oss/tests/fixtures.py.re
```