### PR TITLE
Migrate from PyPI tokens to Trusted Publishers

### DIFF
--- a/dvc-{{cookiecutter.plugin_name}}/.github/workflows/release.yaml
+++ b/dvc-{{cookiecutter.plugin_name}}/.github/workflows/release.yaml
@@ -6,11 +6,13 @@ on:
 
 permissions:
   contents: read
-  id-token: write
 
 jobs:
   pip:
     environment: pypi
+    permissions:
+      contents: read
+      id-token: write
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3

--- a/dvc-{{cookiecutter.plugin_name}}/.github/workflows/release.yaml
+++ b/dvc-{{cookiecutter.plugin_name}}/.github/workflows/release.yaml
@@ -6,9 +6,11 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   pip:
+    environment: pypi
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3

--- a/dvc-{{cookiecutter.plugin_name}}/.github/workflows/release.yaml
+++ b/dvc-{{cookiecutter.plugin_name}}/.github/workflows/release.yaml
@@ -27,5 +27,3 @@ jobs:
         twine check dist/*
     - name: Publish packages to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        password: {% raw %}${{ secrets.PYPI_TOKEN }}{% endraw %}


### PR DESCRIPTION
https://blog.pypi.org/posts/2023-04-20-introducing-trusted-publishers#using-trusted-publishing-with-github-actions