### PR TITLE
Use ephemeral GitHub token for pull requests

### DIFF
--- a/dvc-{{cookiecutter.plugin_name}}/.github/workflows/update-template.yaml
+++ b/dvc-{{cookiecutter.plugin_name}}/.github/workflows/update-template.yaml
@@ -7,6 +7,9 @@ on:
 
 jobs:
   update:
+    permissions:
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -23,4 +26,4 @@ jobs:
       with:
         commit-message: update template
         title: update template
-        token: {% raw %}${{ secrets.WORKFLOW_TOKEN }}{% endraw %}
+        token: {% raw %}${{ github.token }}{% endraw %}


### PR DESCRIPTION
Cleaner, and simpler for @iterative/platform to maintain.