### PR TITLE
remove pylint from hook to skip on pre-commit.ci

### DIFF
--- a/dvc-{{cookiecutter.plugin_name}}/.pre-commit-config.yaml
+++ b/dvc-{{cookiecutter.plugin_name}}/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 ci:
-  skip: [mypy, pylint]
+  skip: [mypy]
 
 repos:
   - hooks:


### PR DESCRIPTION
Otherwise, pre-commit.ci does not run on dvc plugins.